### PR TITLE
Refactored http function into module

### DIFF
--- a/lib/commerce_billing/gateways/base.ex
+++ b/lib/commerce_billing/gateways/base.ex
@@ -31,26 +31,13 @@ defmodule Commerce.Billing.Gateways.Base do
       def unstore(_customer_id, _card_id, _opts) do
         not_implemented
       end
-
-      defp http(method, path, params \\ [], opts \\ []) do
-        credentials = Keyword.get(opts, :credentials)
-        headers     = [{"Content-Type", "application/x-www-form-urlencoded"}]
-        data        = params_to_string(params)
-
-        HTTPoison.request(method, path, data, headers, [hackney: [basic_auth: credentials]])
-      end
-
+      
       defp money_to_cents(amount) when is_float(amount) do
         trunc(amount * 100)
       end
 
       defp money_to_cents(amount) do
         amount
-      end
-
-      defp params_to_string(params) do
-        params |> Enum.filter(fn {_k, v} -> v != nil end)
-               |> URI.encode_query
       end
 
       @doc false

--- a/lib/commerce_billing/gateways/stripe.ex
+++ b/lib/commerce_billing/gateways/stripe.ex
@@ -24,6 +24,8 @@ defmodule Commerce.Billing.Gateways.Stripe do
     Address,
     Response
   }
+  
+  alias Commerce.Billing.HttpRequest
 
   import Poison, only: [decode!: 1]
 
@@ -113,7 +115,10 @@ defmodule Commerce.Billing.Gateways.Stripe do
     config = Keyword.fetch!(opts, :config)
 
     method
-      |> http("#{@base_url}/#{path}", params, credentials: config.credentials)
+      |> HttpRequest.new("#{@base_url}/#{path}")
+      |> HttpRequest.put_body(params, :url_encoded)
+      |> HttpRequest.put_auth(:basic, config.credentials)
+      |> HttpRequest.send
       |> respond
   end
 

--- a/lib/commerce_billing/http_request.ex
+++ b/lib/commerce_billing/http_request.ex
@@ -66,6 +66,9 @@ defmodule Commerce.Billing.HttpRequest do
       |> URI.encode_query
   end
   
-  defp encode_body(_, params),
+  defp encode_body(:json, params),
     do: Poison.encode!(params)
+  
+  defp encode_body(_, params),
+    do: params
 end

--- a/lib/commerce_billing/http_request.ex
+++ b/lib/commerce_billing/http_request.ex
@@ -1,0 +1,71 @@
+defmodule Commerce.Billing.HttpRequest do
+  defstruct [:method, :url, :headers, :body, :auth_mode, :credentials]
+  
+  alias Poison
+  alias Commerce.Billing.HttpRequest
+  
+  def new(method, url) do
+    %HttpRequest{
+      method: method,
+      url: url,
+      headers: [],
+      auth_mode: :none
+    }
+  end
+  
+  def put_body(request, params, encoding) do
+    con_type = content_type(encoding)
+    
+    request
+      |> Map.put(:body, encode_body(encoding, params))
+      |> put_header(con_type)
+  end
+  
+  def put_auth(request, :basic, credentials) do
+    request
+      |> Map.put(:auth_mode, :basic)
+      |> Map.put(:credentials, [hackney: [basic_auth: credentials]])
+  end
+  
+  def put_auth(request, :bearer, token) do
+    request
+      |> Map.put(:auth_mode, :bearer)
+      |> put_header({"Authorization", "bearer #{token}"})
+  end
+  
+  def send(request = %{auth_mode: :basic}) do
+    HTTPoison.request(
+      request.method,
+      request.url,
+      request.body,
+      request.headers,
+      request.credentials)
+  end
+  
+  def send(request) do
+    HTTPoison.request(
+      request.method,
+      request.url,
+      request.body,
+      request.headers,
+      [timeout: 10_000])
+  end
+  
+  defp put_header(request, header),
+    do: Map.put(request, :headers, [header | request.headers])
+  
+  defp content_type(:url_encoded),
+    do: {"Content-Type", "application/x-www-form-urlencoded"}
+    
+  defp content_type(:json),
+    do: {"Content-Type", "application/json"}
+    
+  defp encode_body(:url_encoded, params) do
+    params
+      |> Enum.filter(fn {_k, v} -> v != nil end)
+      |> URI.encode_query
+  end
+  
+  defp encode_body(_, params),
+    do: Poison.encode!(params)
+end

--- a/lib/commerce_billing/http_request.ex
+++ b/lib/commerce_billing/http_request.ex
@@ -47,8 +47,7 @@ defmodule Commerce.Billing.HttpRequest do
       request.method,
       request.url,
       request.body,
-      request.headers,
-      [timeout: 10_000])
+      request.headers)
   end
   
   defp put_header(request, header),

--- a/lib/commerce_billing/http_request.ex
+++ b/lib/commerce_billing/http_request.ex
@@ -8,8 +8,7 @@ defmodule Commerce.Billing.HttpRequest do
     %HttpRequest{
       method: method,
       url: url,
-      headers: [],
-      auth_mode: :none
+      headers: []
     }
   end
   

--- a/test/http_request_test.exs
+++ b/test/http_request_test.exs
@@ -1,0 +1,51 @@
+defmodule Commerce.Billing.HttpRequestTest do
+  use ExUnit.Case
+  
+  alias Commerce.Billing.HttpRequest
+  
+  test "new should return a new valid HttpRequest struct" do
+    request = HttpRequest.new(:post, "http://example.com")
+    
+    assert request == %HttpRequest {
+      method: :post,
+      url: "http://example.com",
+      headers: []
+    }
+  end
+  
+  test "put_body should set the body field using json encoding" do
+    request =
+      HttpRequest.new(:post, "")
+      |> HttpRequest.put_body(%{test: "value"}, :json)
+      
+    assert request.headers == [{"Content-Type", "application/json"}]
+    assert request.body == "{\"test\":\"value\"}"
+  end
+  
+  test "put_body should set the body field using url encoding encoding" do
+    request =
+      HttpRequest.new(:post, "")
+      |> HttpRequest.put_body(%{test: "value"}, :url_encoded)
+      
+    assert request.headers == [{"Content-Type", "application/x-www-form-urlencoded"}]
+    assert request.body == "test=value"
+  end
+  
+  test "put_auth should set auth to basic" do
+    request =
+      HttpRequest.new(:post, "")
+      |> HttpRequest.put_auth(:basic, "user:name")
+    
+    assert request.auth_mode == :basic
+    assert request.credentials == [hackney: [basic_auth: "user:name"]]
+  end
+  
+  test "put_auth should set auth to bearer" do
+    request =
+      HttpRequest.new(:post, "")
+      |> HttpRequest.put_auth(:bearer, "token")
+    
+    assert request.auth_mode == :bearer
+    assert request.headers == [{"Authorization", "bearer token"}]
+  end
+end


### PR DESCRIPTION
I have removed the http function from the base gateway and created a module to support building http requests in a composable manner. This has mainly been done to support sending requests with different auth strategies (supports `:basic` and `:bearer`) and different body encoding (ie, `:url_encoded`, `:json`).